### PR TITLE
Feature/docker workflow

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Docker CI
 
 on:
   push:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -3,10 +3,10 @@ name: Docker CI
 on:
   push:
     tags:
-      - 'v*' 
+      - 'v(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)'
 
 jobs:
-  mvn-build-test:
+  mvn-test:
     runs-on: ubuntu-latest
     steps:
     
@@ -25,12 +25,12 @@ jobs:
       with:
         redis-version: 6
         
-    - name: Build and test with maven
-      run: mvn install
+    - name: Maven test
+      run: mvn -B test
 
   docker-build-push:
     runs-on: ubuntu-latest
-    needs: mvn-build-test
+    needs: mvn-test
     steps:
 
     - name: Checkout code
@@ -44,17 +44,14 @@ jobs:
     
     - name: Build and push the Docker image
       run: |
-        # examples of tag: v1, v1-SNAPSHOT, v1.4-SNAPSHOT, v1.4.5, v1.4.5-SNAPSHOT 
+        # examples of tag: v1, v1.4, v1.4.5
         TAG=$(echo $GITHUB_REF | cut -d / -f 3)
         INPUT_VERSION=$(echo $TAG | cut -d 'v' -f 2)
-        
-        # if $INPUT_VERSION is equal to $TAG, no "v" prefix has beed set to the git tag, so exit with error
-        [ "$INPUT_VERSION" != "$TAG" ] || exit 1
         SPLITTED=(${INPUT_VERSION//./ })
 
         IS_NUM_REGEX="^[0-9]+$"
         
-        # for each number of the version, remove eventual SNAPSHOT suffix and set to 0 if null
+        # for each number of the version, remove eventual SNAPSHOT, alpha, beta suffix and set to 0 if null
         for i in {0..2}
         do
            SPLITTED[$i]=`echo ${SPLITTED[$i]} | cut -d '-' -f 1`
@@ -67,21 +64,16 @@ jobs:
         PATCH_TAG=$MINOR_TAG.${SPLITTED[2]}
 
         IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/tomcat-redis-manager
-        
-        # ----------------------------------------
-        # git tag         -> docker tags
-        # ----------------------------------------
-        # v1              -> 1, 1.0, 1.0.0, latest
-        # v1-SNAPSHOT     -> 1, 1.0, 1.0.0, latest
-        # v1.2            -> 1, 1.2, 1.2.0, latest
-        # v1.2-SNAPSHOT   -> 1, 1.2, 1.2.3, latest
-        # v1.2.3-SNAPSHOT -> 1, 1.2, 1.2.3, latest
-        # ----------------------------------------
+
+        # examples of docker tag generation:
+        # | git tag | generated docker tags |
+        # |---------|-----------------------|
+        # | v1      | 1, 1.0, 1.0.0, latest |
+        # | v1.2    | 1, 1.2, 1.2.0, latest |
+        # | v1.2.3  | 1, 1.2, 1.2.3, latest |
         
         docker build . --file ./Dockerfile --tag $IMAGE_NAME:$MAJOR_TAG --tag $IMAGE_NAME:$MINOR_TAG --tag $IMAGE_NAME:$PATCH_TAG --tag $IMAGE_NAME:latest
 
-        docker push $IMAGE_NAME:$MAJOR_TAG
-        docker push $IMAGE_NAME:$MINOR_TAG
-        docker push $IMAGE_NAME:$PATCH_TAG
-        docker push $IMAGE_NAME:latest
+        # push all generated tags
+        docker push -a $IMAGE_NAME
  

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -3,7 +3,7 @@ name: Docker CI
 on:
   push:
     tags:
-      - 'v(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)'
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
 
 jobs:
   mvn-test:

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -47,16 +47,11 @@ jobs:
         # examples of tag: v1, v1.4, v1.4.5
         TAG=$(echo $GITHUB_REF | cut -d / -f 3)
         INPUT_VERSION=$(echo $TAG | cut -d 'v' -f 2)
-        SPLITTED=(${INPUT_VERSION//./ })
 
-        IS_NUM_REGEX="^[0-9]+$"
-        
-        # for each number of the version, remove eventual SNAPSHOT, alpha, beta suffix and set to 0 if null
+        SPLITTED=(${INPUT_VERSION//./ })
         for i in {0..2}
         do
-           SPLITTED[$i]=`echo ${SPLITTED[$i]} | cut -d '-' -f 1`
            [ "${SPLITTED[$i]}" != "" ] || SPLITTED[$i]=0
-           [[ ${SPLITTED[$i]} =~ $IS_NUM_REGEX ]] || exit 1
         done
         
         MAJOR_TAG=${SPLITTED[0]}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -51,12 +51,15 @@ jobs:
         # if $INPUT_VERSION is equal to $TAG, no "v" prefix has beed set to the git tag, so exit with error
         [ "$INPUT_VERSION" != "$TAG" ] || exit 1
         SPLITTED=(${INPUT_VERSION//./ })
+
+        IS_NUM_REGEX="^[0-9]+$"
         
         # for each number of the version, remove eventual SNAPSHOT suffix and set to 0 if null
         for i in {0..2}
         do
            SPLITTED[$i]=`echo ${SPLITTED[$i]} | cut -d '-' -f 1`
-           [ "${SPLITTED[$i]}" != "" ] || SPLITTED[$i]=0 
+           [ "${SPLITTED[$i]}" != "" ] || SPLITTED[$i]=0
+           [[ SPLITTED[$i] =~ $IS_NUM_REGEX ]] || exit 1
         done
         
         MAJOR_TAG=${SPLITTED[0]}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -59,7 +59,7 @@ jobs:
         do
            SPLITTED[$i]=`echo ${SPLITTED[$i]} | cut -d '-' -f 1`
            [ "${SPLITTED[$i]}" != "" ] || SPLITTED[$i]=0
-           [[ SPLITTED[$i] =~ $IS_NUM_REGEX ]] || exit 998
+           [[ $SPLITTED[$i] =~ $IS_NUM_REGEX ]] || exit 1
         done
         
         MAJOR_TAG=${SPLITTED[0]}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -40,7 +40,7 @@ jobs:
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}   
+        password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
     
     - name: Build and push the Docker image
       run: |

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -59,7 +59,7 @@ jobs:
         do
            SPLITTED[$i]=`echo ${SPLITTED[$i]} | cut -d '-' -f 1`
            [ "${SPLITTED[$i]}" != "" ] || SPLITTED[$i]=0
-           [[ SPLITTED[$i] =~ $IS_NUM_REGEX ]] || exit 1
+           [[ SPLITTED[$i] =~ $IS_NUM_REGEX ]] || exit 998
         done
         
         MAJOR_TAG=${SPLITTED[0]}

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -59,7 +59,7 @@ jobs:
         do
            SPLITTED[$i]=`echo ${SPLITTED[$i]} | cut -d '-' -f 1`
            [ "${SPLITTED[$i]}" != "" ] || SPLITTED[$i]=0
-           [[ $SPLITTED[$i] =~ $IS_NUM_REGEX ]] || exit 1
+           [[ ${SPLITTED[$i]} =~ $IS_NUM_REGEX ]] || exit 1
         done
         
         MAJOR_TAG=${SPLITTED[0]}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,12 @@ jobs:
     
     - name: Checkout code
       uses: actions/checkout@v2
+      
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}   
     
     - name: Build the Docker image
       run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,8 +22,40 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}   
     
-    - name: Build the Docker image
+    - name: Build and push the Docker image
       run: |
+        # examples of tag: v1, v1-SNAPSHOT, v1.4-SNAPSHOT, v1.4.5, v1.4.5-SNAPSHOT 
         TAG=$(echo $GITHUB_REF | cut -d / -f 3)
-        docker build . --file ./Dockerfile --tag my-image-name:$TAG
+        INPUT_VERSION=$(echo $TAG | cut -d 'v' -f 2)
+        
+        # if $INPUT_VERSION is equal to $TAG, no "v" prefix has beed set to the git tag, so exit with error
+        [ "$INPUT_VERSION" != "$TAG" ] || exit 1
+        SPLITTED=(${INPUT_VERSION//./ })
+        
+        # for each number of the version, remove eventual SNAPSHOT suffix and set to 0 if null
+        for i in {0..2}
+        do
+           SPLITTED[$i]=`echo ${SPLITTED[$i]} | cut -d '-' -f 1`
+           [ "${SPLITTED[$i]}" != "" ] || SPLITTED[$i]=0 
+        done
+        
+        MAJOR_TAG=${SPLITTED[0]}
+        MINOR_TAG=$MAJOR_TAG.${SPLITTED[1]}
+        PATCH_TAG=$MINOR_TAG.${SPLITTED[2]}
+
+        IMAGE_NAME=${{ secrets[env.DOCKER_USERNAME] }}/tomcat-redis-manager
+        
+        # ----------------------------------------
+        # git tag         -> docker tags
+        # ----------------------------------------
+        # v1              -> 1, 1.0, 1.0.0, latest
+        # v1-SNAPSHOT     -> 1, 1.0, 1.0.0, latest
+        # v1.2            -> 1, 1.2, 1.2.0, latest
+        # v1.2-SNAPSHOT   -> 1, 1.2, 1.2.3, latest
+        # v1.2.3-SNAPSHOT -> 1, 1.2, 1.2.3, latest
+        # ----------------------------------------
+        
+        docker build . --file ./Dockerfile --tag $IMAGE_NAME:$MAJOR_TAG --tag $IMAGE_NAME:$MINOR_TAG --tag $IMAGE_NAME:$PATCH_TAG --tag $IMAGE_NAME:latest
+
+        docker push --all-tags
  

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,5 +57,8 @@ jobs:
         
         docker build . --file ./Dockerfile --tag $IMAGE_NAME:$MAJOR_TAG --tag $IMAGE_NAME:$MINOR_TAG --tag $IMAGE_NAME:$PATCH_TAG --tag $IMAGE_NAME:latest
 
-        docker push --all-tags
+        docker push $IMAGE_NAME:$MAJOR_TAG
+        docker push $IMAGE_NAME:$MINOR_TAG
+        docker push $IMAGE_NAME:$PATCH_TAG
+        docker push $IMAGE_NAME:latest
  

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,12 +13,11 @@ jobs:
 
     steps:
     
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
+    
     - name: Build the Docker image
       run: |
         TAG=$(echo $GITHUB_REF | cut -d / -f 3)
-        echo "tag: $TAG"
-        ls
-        pwd
-        docker build -t my-image-name:${TAG} .
+        docker build . --file ./Dockerfile --tag my-image-name:$TAG
  

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}   
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}   
     
     - name: Build and push the Docker image
       run: |
@@ -43,7 +43,7 @@ jobs:
         MINOR_TAG=$MAJOR_TAG.${SPLITTED[1]}
         PATCH_TAG=$MINOR_TAG.${SPLITTED[2]}
 
-        IMAGE_NAME=${{ secrets[env.DOCKER_USERNAME] }}/tomcat-redis-manager
+        IMAGE_NAME=${{ secrets[env.DOCKERHUB_USERNAME] }}/tomcat-redis-manager
         
         # ----------------------------------------
         # git tag         -> docker tags

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,7 +43,7 @@ jobs:
         MINOR_TAG=$MAJOR_TAG.${SPLITTED[1]}
         PATCH_TAG=$MINOR_TAG.${SPLITTED[2]}
 
-        IMAGE_NAME=${{ secrets[env.DOCKERHUB_USERNAME] }}/tomcat-redis-manager
+        IMAGE_NAME=${{ secrets.DOCKERHUB_USERNAME }}/tomcat-redis-manager
         
         # ----------------------------------------
         # git tag         -> docker tags

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,11 +6,30 @@ on:
       - 'v*' 
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    
+    - name: Checkout sources
+      uses: actions/checkout@v2
+      
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+        
+    - name: Start Redis
+      uses: supercharge/redis-github-action@1.1.0
+      with:
+        redis-version: 6
+        
+    - name: Build and Test with maven
+      run: mvn install
 
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     
     - name: Checkout code

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,5 +17,8 @@ jobs:
     - name: Build the Docker image
       run: |
         TAG=$(echo $GITHUB_REF | cut -d / -f 3)
-        docker build . --file Dockerfile --tag my-image-name:$TAG
-     
+        echo "tag: $TAG"
+        ls
+        pwd
+        docker build -t my-image-name:${TAG} .
+ 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,21 @@
+name: Docker Image CI
+
+on:
+  push:
+    tags:
+      - 'v*' 
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: |
+        TAG=$(echo $GITHUB_REF | cut -d / -f 3)
+        docker build . --file Dockerfile --tag my-image-name:$TAG
+     

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Maven CI
 on: pull_request
 
 jobs:

--- a/.github/workflows/maven-ci.yml
+++ b/.github/workflows/maven-ci.yml
@@ -2,8 +2,8 @@ name: Maven CI
 on: pull_request
 
 jobs:
-  mvn-build-tests:
-    name: "Run maven build and tests"
+  mvn-tests:
+    name: "Run maven compile and tests"
     runs-on: ubuntu-latest
     steps:
 
@@ -22,5 +22,5 @@ jobs:
       with:
         redis-version: 6
 
-    - name: Maven build
-      run: mvn install
+    - name: Maven test
+      run: mvn -B test

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
     test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,5 @@ COPY src ./src
 COPY pom.xml .
 RUN mvn clean package -DskipTests
 
-# FROM tomcat:8.5-jre11-temurin-focal
-FROM tomcat:9.0.52-jre11-temurin-focal
-# FROM tomcat:jdk11-adoptopenjdk-openj9
+FROM tomcat:8.5-jre11-temurin-focal
 COPY --from=build /tmp/target/tomcat-redis-manager-*-shaded.jar $CATALINA_HOME/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# use this commands to build and push a tomcat image that includes this stores inside the /lib dir
+# $repo=your/repo
+# $maj=<major version>
+# $min=<minor version>
+# $patch=<patch version>
+# docker build -t $repo:latest .
+# docker push $repo:latest
+# docker tag $repo:latest $repo:$maj
+# docker push $repo:$maj
+# docker tag $repo:latest $repo:$maj.$min
+# docker push $repo:$maj.$min
+# docker tag $repo:latest $repo:$maj.$min.$patch
+# docker push $repo:$maj.$min.$patch
+
+FROM maven:3.8-eclipse-temurin-11 AS build
+WORKDIR /tmp
+COPY src ./src
+COPY pom.xml .
+RUN mvn clean package -DskipTests
+
+FROM tomcat:8.5-jre11-temurin-focal
+COPY --from=build /tmp/target/redis-manager-*-shaded.jar $CATALINA_HOME/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ COPY src ./src
 COPY pom.xml .
 RUN mvn clean package -DskipTests
 
-FROM tomcat:8.5-jre11-temurin-focal
-COPY --from=build /tmp/target/redis-manager-*-shaded.jar $CATALINA_HOME/lib
+# FROM tomcat:8.5-jre11-temurin-focal
+FROM tomcat:9.0.52-jre11-temurin-focal
+# FROM tomcat:jdk11-adoptopenjdk-openj9
+COPY --from=build /tmp/target/tomcat-redis-manager-*-shaded.jar $CATALINA_HOME/lib

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-This is a Tomcat session manager that saves sessions in Redis for easy distribution of requests across a cluster of
+This is a Tomcat session manager that saves sessions in Redis for an easy distribution of requests across a cluster of
 Tomcat servers. Obviously, data stored in the session must be Serializable.
 
 You can use this library as a dependency inside your project, or you can embed the shaded jar inside the `/lib` directory of the Tomcat.

--- a/README.md
+++ b/README.md
@@ -115,14 +115,11 @@ This project takes advantage of a *github workflow* for the releases, so:
 
 When you push a new tag in the form of `v<MAJOR>` or `v<MAJOR><MINOR>` or `v<MAJOR>.<MINOR>.<PATCH>` a series of new tags for your Docker image are generated according to the following schema:
 
-| git tag         | generated docker tags |
-|-----------------|-----------------------|
-| v1              | 1, 1.0, 1.0.0, latest |
-| v1-SNAPSHOT     | 1, 1.0, 1.0.0, latest |
-| v1.2            | 1, 1.2, 1.2.0, latest |
-| v1.2-SNAPSHOT   | 1, 1.2, 1.2.0, latest |
-| v1.2.3          | 1, 1.2, 1.2.3, latest |
-| v1.2.3-SNAPSHOT | 1, 1.2, 1.2.3, latest |
+| git tag | generated docker tags |
+|---------|-----------------------|
+| v1      | 1, 1.0, 1.0.0, latest |
+| v1.2    | 1, 1.2, 1.2.0, latest |
+| v1.2.3  | 1, 1.2, 1.2.3, latest |
 
 In order to help releasing new tags according to this schema, you can add these ***git aliases***:
 
@@ -151,9 +148,9 @@ Some usage examples might be:
 $ git release --usage
 Creates a new tag from the current commit.
 Usage: 
-  git release [--patch] [--snapshot] # creates a new patch release 
-  git release  --minor  [--snapshot] # creates a new minor release  
-  git release  --major  [--snapshot] # creates a new major release 
+  git release [--patch] # creates a new patch release 
+  git release  --minor  # creates a new minor release  
+  git release  --major  # creates a new major release 
   
 $ git release
 Latest tag found: v1.3.5
@@ -163,25 +160,13 @@ $ git release --patch
 Latest tag found: v1.3.6
 New release tag:  v1.3.7
 
-$ git release --snapshot
-Latest tag found: v1.3.7
-New release tag:  v1.3.8-SNAPSHOT
-
 $ git release --minor 
-Latest tag found: v1.3.8-SNAPSHOT
+Latest tag found: v1.3.7
 New release tag:  v1.4.0
 
-$ git release --minor --snapshot
-Latest tag found: v1.4.0
-New release tag:  v1.5-SNAPSHOT.0
-
 $ git release --major
-Latest tag found: v1.5-SNAPSHOT.0
+Latest tag found: v1.5.0
 New release tag:  v2.0.0
-
-$ git release --major --snapshot
-Latest tag found: v2.0.0
-New release tag:  v3-SNAPSHOT.0.0
 ```
 When you create a new tag using the `git release` alias, you have to push it to the remote in order to trigger the github workflow and to release new Docker images:
 ```bash
@@ -214,9 +199,9 @@ git config --global alias.release '!f() {
        echo "" 
        echo "Creates a ${BOLD}${YELLOW}new tag${RESET} from the current commit."
        echo "Usage: "
-       echo "  git release ${GREEN}[--patch] [--snapshot] ${CYAN}# creates a new patch release ${RESET}"
-       echo "  git release  --minor  ${GREEN}[--snapshot] ${CYAN}# creates a new minor release  ${RESET}"
-       echo "  git release  --major  ${GREEN}[--snapshot] ${CYAN}# creates a new major release  ${RESET}"
+       echo "  git release ${GREEN}[--patch] ${CYAN}# creates a new patch release ${RESET}"
+       echo "  git release  --minor  ${CYAN}# creates a new minor release  ${RESET}"
+       echo "  git release  --major  ${CYAN}# creates a new major release  ${RESET}"
        exit 0
     elif [[ "$1" == "--major" ]]; then                           
        SPLITTED[0]=$((SPLITTED[0]+1))   
@@ -230,10 +215,7 @@ git config --global alias.release '!f() {
     else                                                       
        SPLITTED[2]=$((SPLITTED[2]+1))                          
     fi                                                         
-                                                               
-    if [ "$1" == "--snapshot" ] || [ "$2" == "--snapshot" ]; then                         
-       SPLITTED[$INDEX]=${SPLITTED[$INDEX]}-SNAPSHOT           
-    fi                                                         
+                                                       
     echo "Latest tag found: ${BOLD}${YELLOW} `git lasttag`${RESET}"                                                           
     git tag v${SPLITTED[0]}.${SPLITTED[1]}.${SPLITTED[2]}      
     echo "New release tag: ${BOLD}${GREEN} `git lasttag`${RESET}"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Tomcat servers. Obviously, data stored in the session must be Serializable.
 You can use this library as a dependency inside your project, or you can embed the shaded jar inside the `/lib` directory of the Tomcat.
 
 
-> In this version only Tomcat 8.5 is supported, newer version of tomcat has not been tested yet.
+> In this version only Tomcat 8.5 is supported, newer versions of tomcat have not been tested yet.
 
 ## How to build
 


### PR DESCRIPTION
Changes:
- better indentation of the existing github workflow;
- implemented a maven install (+ tests) in place of only tests in the existing workflow;
- renamed existing workflow;
- created a subsequent workflow to deploy on Dockerhub the generated tasks;
- updated README.

Notes: 
- Some tiny changes on the README were only meant to trigger a new release tag.
- I've set the Repository Secrets as DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD.
- I've suggested some git aliases to work with this workflow to limit the programmer errors in the task of releasing a new tag in the right form.
- I've chosed git tagging style as (vMAJOR.MINOR.PATCH) because it's recommended and used by [semver.org](https://github.com/semver/semver/releases/tag/v2.0.0) the organization for the semantic versioning and by [Atlassian official guides on git tagging](https://www.atlassian.com/git/tutorials/inspecting-a-repository/git-tag).
