### PR TITLE
Session draining on demand

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.22.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,13 @@
             <version>3.22.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/overit/tomcat/redis/RedisConnector.java
+++ b/src/main/java/com/overit/tomcat/redis/RedisConnector.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
  *
  * <p>Use the static {@link #instance()} method to get a singleton instance of this driver and connect with the local
  * redis service ({@code redis://localhost:6379}). Otherwise, it is possible to use the {@link #setUrl(String)} method
- * to specify another connection url, or even you can configure the comunication timeouts using the {@link #setConnectionTimeout(int)} and
+ * to specify another connection url, or even you can configure the communication timeouts using the {@link #setConnectionTimeout(int)} and
  * {@link #setSoTimeout(int)} methods.</p>
  *
  * <p><em>You have to call the setter methods before the {@link #instance()}</em>.</p>
@@ -28,7 +28,7 @@ import java.util.function.Function;
  * @author Mauro Manfrin
  * @author Alessandro Modolo
  */
-public class RedisConnector {
+class RedisConnector {
 
     private static final Log log = LogFactory.getLog(RedisConnector.class);
     private static String url = "redis://localhost:6379";
@@ -139,12 +139,29 @@ public class RedisConnector {
     }
 
     /**
-     * TODO
-     * @param channel
-     * @param message
+     * Broadcast a message via the specified channel. The message will be received by all agents that has been
+     * {@link #subscribe(JedisPubSub, String...) subscribed} to this channel
+     *
+     * @param channel the channel against with send the message
+     * @param message the message payload
      */
     public void publish(String channel, String message) {
         execute(client -> client.publish(channel, message));
+    }
+
+    /**
+     * Subscribe to all the messages received from the specified channels.
+     * <br/>
+     * <em>WARNING: This method will block the current thread until the un-subscription</em>
+     *
+     * @param subscriber instance of the subscriber interface
+     * @param channels   channels from which receive the notifications
+     */
+    public void subscribe(JedisPubSub subscriber, String... channels) {
+        execute(client -> {
+            client.subscribe(subscriber, channels);
+            return null;
+        });
     }
 
     /**
@@ -185,7 +202,7 @@ public class RedisConnector {
     }
 
     /**
-     * Delete the keys that matches a given pattern and belongs to a specific type
+     * Delete the keys that match a given pattern and belongs to a specific type
      *
      * @param pattern the pattern string
      * @param type    string representation of the type of the value stored at key. The different types that can be used

--- a/src/main/java/com/overit/tomcat/redis/RedisConnector.java
+++ b/src/main/java/com/overit/tomcat/redis/RedisConnector.java
@@ -139,6 +139,15 @@ public class RedisConnector {
     }
 
     /**
+     * TODO
+     * @param channel
+     * @param message
+     */
+    public void publish(String channel, String message) {
+        execute(client -> client.publish(channel, message));
+    }
+
+    /**
      * Extract the keys that matches a given pattern and belongs to a specific type
      *
      * @param pattern the pattern string

--- a/src/main/java/com/overit/tomcat/redis/RedisStore.java
+++ b/src/main/java/com/overit/tomcat/redis/RedisStore.java
@@ -22,7 +22,7 @@ import java.util.List;
  * @author Alessandro Modolo
  * @author Mauro Manfrin
  */
-public final class RedisStore extends StoreBase {
+public class RedisStore extends StoreBase {
 
     private static final Log log = LogFactory.getLog(RedisStore.class);
     private static final String SESSION_DRAINING_CHANNEL = "SESSION_DRAINING_CHANNEL";
@@ -265,7 +265,7 @@ public final class RedisStore extends StoreBase {
         }
     }
 
-    private boolean askForSessionDraining(String id, long start, boolean firstRetry) throws InterruptedException {
+    boolean askForSessionDraining(String id, long start, boolean firstRetry) throws InterruptedException {
         if (System.currentTimeMillis() - start > 2000) return false;
         if (firstRetry) {
             RedisConnector.instance().publish(SESSION_DRAINING_CHANNEL, id);
@@ -275,7 +275,7 @@ public final class RedisStore extends StoreBase {
         return askForSessionDraining(id, start, false);
     }
 
-    private boolean someOneAnsweredMe(String id) {
+    boolean someOneAnsweredMe(String id) {
         return RedisConnector.instance().execute(client -> {
             String key = getSessionKey(id)+":requested";
             Transaction t = client.multi();
@@ -305,7 +305,7 @@ public final class RedisStore extends StoreBase {
         });
     }
 
-    private Session awaitAndLoad(String id, long start) throws Exception {
+    Session awaitAndLoad(String id, long start) throws Exception {
         if (System.currentTimeMillis() - start > MAX_AWAITING_LOADING_TIME) return null;
 
         byte[] raw = loadSession(id);

--- a/src/main/java/com/overit/tomcat/redis/RedisSubscriberService.java
+++ b/src/main/java/com/overit/tomcat/redis/RedisSubscriberService.java
@@ -1,0 +1,42 @@
+package com.overit.tomcat.redis;
+
+import redis.clients.jedis.JedisPubSub;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+class RedisSubscriberService implements Runnable {
+
+    private static final String SESSION_DRAINING_CHANNEL = "SESSION_DRAINING_CHANNEL";
+
+    private final List<Consumer<String>> subscribers = new CopyOnWriteArrayList<>();
+    private final JedisPubSub subscriber = new JedisPubSub() {
+        @Override
+        public void onMessage(String channel, String sessionId) {
+            subscribers.forEach(handler -> handler.accept(sessionId));
+        }
+    };
+
+    @Override
+    public void run() {
+        RedisConnector.instance().subscribe(subscriber, getSubscribeChannel());
+    }
+
+    public void subscribe(Consumer<String> handler) {
+        subscribers.add(handler);
+    }
+
+    public void unsubscribe(Consumer<String> handler) {
+        subscribers.remove(handler);
+    }
+
+    public void unsubscribe() {
+        subscriber.unsubscribe();
+        subscribers.clear();
+    }
+
+    public String getSubscribeChannel() {
+        return SESSION_DRAINING_CHANNEL;
+    }
+}

--- a/src/main/java/com/overit/tomcat/redis/RedisSubscriberServiceManager.java
+++ b/src/main/java/com/overit/tomcat/redis/RedisSubscriberServiceManager.java
@@ -1,0 +1,39 @@
+package com.overit.tomcat.redis;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+class RedisSubscriberServiceManager {
+    private static RedisSubscriberServiceManager instance;
+    private final RedisSubscriberService service;
+    private Future<?> task;
+
+    public static synchronized RedisSubscriberServiceManager getInstance() {
+        if (instance == null) {
+            instance = new RedisSubscriberServiceManager(new RedisSubscriberService());
+        }
+        return instance;
+    }
+
+    public RedisSubscriberServiceManager(RedisSubscriberService service) {
+        this.service = service;
+        start();
+    }
+
+    void start() {
+        task = Executors.newSingleThreadExecutor().submit(service);
+    }
+
+    void stop() {
+        service.unsubscribe();
+        task.cancel(true);
+    }
+
+    public RedisSubscriberService getService() {
+        return service;
+    }
+
+    public String getSubscribeChannel() {
+        return service.getSubscribeChannel();
+    }
+}

--- a/src/test/java/com/overit/tomcat/redis/RedisStoreTest.java
+++ b/src/test/java/com/overit/tomcat/redis/RedisStoreTest.java
@@ -2,6 +2,7 @@ package com.overit.tomcat.redis;
 
 import com.overit.tomcat.TesterContext;
 import com.overit.tomcat.TesterServletContext;
+import org.apache.catalina.LifecycleException;
 import org.apache.catalina.Manager;
 import org.apache.catalina.Session;
 import org.apache.catalina.session.StandardManager;
@@ -10,21 +11,28 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
+import java.io.NotSerializableException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RedisStoreTest {
     @Spy
     private RedisStore store;
+    @Captor
+    private ArgumentCaptor<Session> sessionArgumentCaptor;
+
     private Manager manager;
 
     @Before
@@ -46,6 +54,143 @@ public class RedisStoreTest {
         store.stop();
     }
 
+    @Test
+    public void getSize() {
+        assertThat(store.getSize()).isEqualTo(2);
+    }
+
+    @Test
+    public void clear() {
+        store.clear();
+        assertThat(store.getSize()).isZero();
+    }
+
+    @Test
+    public void keys() {
+        assertThat(store.keys()).containsExactlyInAnyOrder("s1", "s2");
+        store.clear();
+        assertThat(store.keys()).isEmpty();
+    }
+
+    @Test
+    public void remove() {
+        store.remove("s1");
+        assertThat(store.getSize()).isEqualTo(1);
+    }
+
+    @Test
+    public void add() throws IOException {
+        store.save(createSession("s3"));
+        assertThat(store.getSize()).isEqualTo(3);
+        assertThat(store.keys()).containsExactlyInAnyOrder("s1", "s2", "s3");
+    }
+
+    @Test(expected = NotSerializableException.class)
+    public void save_nonSerializableSession_shouldThrows() throws IOException {
+        // given
+        Session session = createSession("s");
+        session.getSession().setAttribute("notserializable", new Object());
+
+        // when()
+        store.save(session);
+    }
+
+    @Test
+    public void load() {
+        Session s2 = store.load("s2");
+        assertThat(s2.getIdInternal()).isEqualTo("s2");
+    }
+
+    @Test
+    public void load_havingNoStoredSessionAndNoOneCanDrainIt_shouldReturnNullIn2Seconds() {
+        // given
+        long start = System.currentTimeMillis();
+
+        // when
+        Session session = store.load("unknown");
+
+        // then
+        long end = System.currentTimeMillis();
+        assertThat(session).isNull();
+        assertThat(end - start).isBetween(2000L, 2500L);
+    }
+
+    @Test
+    public void load_havingNoStoredSessionButSomeoneThatCanDrainIt_shouldReturnNotNull() throws Exception {
+        // give
+        String sessionId = "s4";
+        AtomicLong start = new AtomicLong();
+        AtomicLong stop = new AtomicLong();
+        when(store.askForSessionDraining(eq(sessionId), anyLong(), eq(true))).thenAnswer(updateTimeAndCallRealMethod(start));
+        when(store.awaitAndLoad(eq(sessionId), anyLong())).thenAnswer(updateTimeAndCallRealMethod(stop));
+        scheduleResponseExecution(sessionId);
+
+        // when
+        Session session = store.load(sessionId);
+
+        // then
+        assertThat(session.getIdInternal()).isEqualTo(sessionId);
+        assertThat(stop.get() - start.get()).isLessThanOrEqualTo(2000);
+    }
+
+
+    @Test
+    public void onSessionDrainRequest_whenReceiveARequestNotification_shouldCallTheMethod() {
+        // when
+        store.sendSessionDrainingRequest("");
+
+        // then
+        verify(store).onSessionDrainRequest("");
+    }
+
+    @Test
+    public void onSessionDrainRequest_whenReceiveARequestNotificationOfUnknownSession_shouldNotWriteAnything() {
+        // when
+        store.sendSessionDrainingRequest("unknown");
+
+        // then
+        String key = store.getSessionRequestKey("unknown");
+        String value = RedisConnector.instance().execute(client -> client.get(key));
+        assertThat(value).isNull();
+    }
+
+    @Test
+    public void onSessionDrainRequest_whenReceiveARequestNotification_shouldAddResponseIntoRedisEntry() throws InterruptedException {
+        // when
+        store.sendSessionDrainingRequest("s1");
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        // then
+        String key = store.getSessionRequestKey("s1");
+        String value = RedisConnector.instance().execute(client -> client.get(key));
+        assertThat(value).isEqualTo("true");
+    }
+
+    @Test
+    public void onSessionDrainRequest_whenReceiveARequestNotification_shouldSaveTheSession() throws InterruptedException {
+        // when
+        store.sendSessionDrainingRequest("s1");
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        // then
+        byte[] session = store.loadSession("s1");
+        assertThat(session).isNotEmpty();
+    }
+
+    @Test
+    public void onSessionDrainingRequest_whenReceiveARequestForAProcessingSession_shouldWaitTheProcessingComplete() throws IOException {
+        // give
+        Session session = createSession("s3");
+        simulateTaskProcessingOnSession(session);
+
+        // when
+        store.onSessionDrainRequest("s3");
+
+        // then
+        verify(store, atLeastOnce()).save(sessionArgumentCaptor.capture());
+        assertThat(sessionArgumentCaptor.getValue().getSession().getAttribute("processing")).isEqualTo(false);
+    }
+
     private Session createSession(String id) {
         StandardSession session = new StandardSession(manager);
         session.setNew(true);
@@ -57,86 +202,33 @@ public class RedisStoreTest {
         return session;
     }
 
-    @Test
-    public void getSize() {
-        assertEquals(2, store.getSize());
+    private void scheduleResponseExecution(String sessionId) {
+        String key = store.getSessionRequestKey(sessionId);
+        RedisConnector.instance().execute(j -> j.set(key, "true"));
+        Executors.newSingleThreadScheduledExecutor().schedule(
+            () -> {
+                try {
+                    store.save(createSession("s4"));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            },
+            1L, TimeUnit.SECONDS
+        );
     }
 
-    @Test
-    public void clear() {
-        store.clear();
-        assertEquals(0, store.getSize());
-    }
-
-    @Test
-    public void keys() {
-        assertArrayEquals(new String[]{"s1", "s2"}, store.keys());
-        store.clear();
-        assertArrayEquals(new String[]{}, store.keys());
-    }
-
-    @Test
-    public void remove() {
-        store.remove("s1");
-        assertEquals(1, store.getSize());
-    }
-
-    @Test
-    public void add() throws IOException {
-        store.save(createSession("s3"));
-        assertEquals(3, store.getSize());
-        assertArrayEquals(new String[]{"s1", "s2", "s3"}, store.keys());
-    }
-
-    @Test
-    public void load() {
-        Session s2 = store.load("s2");
-        assertNotNull(s2);
-        assertEquals("s2", s2.getIdInternal());
-    }
-
-    @Test
-    public void load_havingNoStoredSessionAndNoOneCanDrainIt_shouldReturnNull() {
-        // given
-        long start = System.currentTimeMillis();
-
-        // when
-        Session session = store.load("unknown");
-
-        // then
-        long now = System.currentTimeMillis();
-        assertThat(session).isNull();
-        assertThat(now - start).isBetween(2000L, 2500L);
-    }
-
-    @Test
-    public void load_havingNoStoredSessionAndItIsDrainedLater_shouldReturnNotNull() throws Exception {
-        // give
-        String key = "tomcat:session:s4:requested";
-        AtomicLong start = new AtomicLong();
-        AtomicLong stop = new AtomicLong();
-        when(store.askForSessionDraining(anyString(), anyLong(), anyBoolean())).thenAnswer(invocation -> {
+    private Answer<Object> updateTimeAndCallRealMethod(AtomicLong start) {
+        return invocation -> {
             start.set(System.currentTimeMillis());
             return invocation.callRealMethod();
-        });
-        when(store.awaitAndLoad(anyString(), anyLong())).thenAnswer(invocation -> {
-            stop.set(System.currentTimeMillis());
-            return invocation.callRealMethod();
-        });
+        };
+    }
 
-        RedisConnector.instance().execute(j -> j.set(key, "true"));
-        Executors.newFixedThreadPool(1).submit(() -> {
-            try {
-                Thread.sleep(1000);
-                store.save(createSession("s4"));
-            } catch (IOException | InterruptedException e) {
-                e.printStackTrace();
-            }
-        });
-
-        Session session = store.load("s4");
-
-        assertThat(session).isNotNull();
-        assertThat(stop.get() - start.get()).isLessThanOrEqualTo(2000);
+    private void simulateTaskProcessingOnSession(Session session) {
+        session.getSession().setAttribute("processing", true);
+        Executors.newSingleThreadScheduledExecutor().schedule(
+            () -> session.getSession().setAttribute("processing", false),
+            1L, TimeUnit.SECONDS
+        );
     }
 }

--- a/src/test/java/com/overit/tomcat/redis/RedisStoreTest.java
+++ b/src/test/java/com/overit/tomcat/redis/RedisStoreTest.java
@@ -4,6 +4,8 @@ import org.apache.catalina.Manager;
 import org.apache.catalina.Session;
 import org.apache.catalina.session.StandardManager;
 import org.apache.catalina.session.StandardSession;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.data.Offset;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -12,6 +14,9 @@ import com.overit.tomcat.TesterContext;
 import com.overit.tomcat.TesterServletContext;
 
 import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class RedisStoreTest {
     private RedisStore store;
@@ -84,5 +89,18 @@ public class RedisStoreTest {
         Session s2 = store.load("s2");
         Assert.assertNotNull(s2);
         Assert.assertEquals("s2", s2.getIdInternal());
+    }
+
+    @Test
+    public void load_havingNoStoredSessionAndNoOneCanDrainIt_shouldReturnNull() {
+        long start = System.currentTimeMillis();
+
+        Session session = store.load("unknown");
+
+        long now = System.currentTimeMillis();
+
+        assertThat(session).isNull();
+        assertThat(now-start).isCloseTo(2000, Offset.offset(500L));
+
     }
 }


### PR DESCRIPTION
allows to retrive a web session from one node (that currently doesn't has the required session id) from the owner node by sending a broadcast message towards Redis.