### PR TITLE
open some java modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,9 @@ RUN mvn clean package -DskipTests
 
 FROM tomcat:10.1.18-jre17-temurin-jammy
 COPY --from=build /tmp/target/tomcat-redis-manager-*-shaded.jar $CATALINA_HOME/lib
+ENV JAVA_OPTS=--"--add-opens java.base/java.lang=ALL-UNNAMED \
+                 --add-opens java.base/java.lang.invoke=ALL-UNNAMED \
+                 --add-opens java.base/java.util=ALL-UNNAMED \
+                 --add-opens java.base/java.util.regex=ALL-UNNAMED \
+                 --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED"
+EXPOSE 8080


### PR DESCRIPTION
edit JAVA_OPTS env variable to open following java modules to unnamed ones:
- java.lang
- java.lang.invoke
- java.util
- java.util.regex
- java.util.concurrent.atomic